### PR TITLE
Export application port value

### DIFF
--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -4,3 +4,6 @@
 
 # Message of the Day
 message = "Hello, World!"
+
+[app]
+port = 8000

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,7 +2,9 @@ pkg_name=sample-node-app
 pkg_origin=your_origin
 pkg_scaffolding="core/scaffolding-node"
 pkg_version="1.0.1"
-
+pkg_exports=(
+    [port]="app.port"
+)
 declare -A scaffolding_env
 
 # Define path to config file


### PR DESCRIPTION
The Node scaffolding allows you to set the port the application is
listening on by setting an `app.port` configuration value.

This change makes that explicit, and also exports the value as
`"port"`, making it useful for larger multi-service demonstrations.

Signed-off-by: Christopher Maier <cmaier@chef.io>