### PR TITLE
Fix alignment on home page, replace README screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For the full experience, check out the [Habitat Demo instructions](https://www.h
 
 Alternatively, you can use the instructions below if you simply want to build and run the app locally.
 
-![habitat-sample-node-app](https://user-images.githubusercontent.com/446285/31078915-96033340-a749-11e7-906c-7861521894fc.png)
+![habitat-sample-node-app](https://user-images.githubusercontent.com/274700/39158589-d1170792-4715-11e8-8e2a-1a2696944500.png)
 
 
 ## Instructions
@@ -46,7 +46,7 @@ pkg_name=sample-node-app
 pkg_origin=your_origin
 pkg_scaffolding="core/scaffolding-node"
 ```
-First, change the value of `your_origin` to the origin name your created in the previous section. 
+First, change the value of `your_origin` to the origin name your created in the previous section.
 
 If you're following the [demo instructions](https://www.habitat.sh/demo/), then use the origin name you created in the Builder web app.
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -30,15 +30,11 @@ footer {
 .logos {
   margin: 4em auto 0;
   width: 340px;
+  display: flex;
 }
 
-.habitat-logo {
-  float: left;
-}
-
-.nodejs-logo {
-  float: right;
-  margin-top: 15px;
+.logos img {
+  padding: 0 16px;
 }
 
 .habicat-jumping {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -7,11 +7,8 @@ html
     block content
 
   section.logos
-    .habitat-logo
-      img(src="images/habitat-logo-by-chef.svg" alt="Habitat logo")
-
-    .nodejs-logo
-      img(src="images/nodejs-logo.svg" alt="NodeJS logo")
+    img(src="images/habitat-logo-by-chef.svg" alt="Habitat logo")
+    img(src="images/nodejs-logo.svg" alt="NodeJS logo")
 
   footer
     img.habicat-jumping(src="images/image-cat-jumping.svg" alt="Habicat jumping")


### PR DESCRIPTION
This fixes the alignment of the Habitat and Node logos on the home pages, and includes a matching screenshot for the README.

Signed-off-by: Christian Nunciato <chris@nunciato.org>