### PR TITLE
Use port 8000 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then exit the Studio:
 And start a Docker container with your newly created image:
 
 ```
-$ docker run -it -p 3000:3000 <YOUR_ORIGIN>/sample-node-app
+$ docker run -it -p 8000:8000 <YOUR_ORIGIN>/sample-node-app
 ```
 
-Now head to http://localhost:3000 and see your running app!
+Now head to http://localhost:8000 and see your running app!

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var app = require('./app');
 var http = require('http');
-var port = process.env.PORT || 3000;
+var port = process.env.PORT || 8000;
 
 app.set('port', port);
 


### PR DESCRIPTION
This fix brings it back in line with existing docs, e.g., https://www.habitat.sh/demo/packaging-system/steps/6/. 

Signed-off-by: Christian Nunciato <chris@nunciato.org>